### PR TITLE
fix linux build

### DIFF
--- a/build_llama.zig
+++ b/build_llama.zig
@@ -62,6 +62,8 @@ pub const Context = struct {
         const lib_opt = .{ .name = "llama.cpp", .target = ctx.options.target, .optimize = ctx.options.optimize };
         const lib = if (ctx.options.shared) ctx.b.addSharedLibrary(lib_opt) else ctx.b.addStaticLibrary(lib_opt);
         ctx.addAll(lib);
+        if (ctx.options.target.getAbi() != .msvc)
+            lib.defineCMacro("_GNU_SOURCE", null);
         if (ctx.options.shared) {
             lib.defineCMacro("LLAMA_SHARED", null);
             lib.defineCMacro("LLAMA_BUILD", null);


### PR DESCRIPTION
Building fails for me on ubuntu now.
```
zig build-lib llama.cpp Debug native: error: error(compilation): clang failed with stderr: ~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16002:22: error: call to undeclared function 'CPU_ALLOC_SIZE'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16004:24: error: call to undeclared function 'CPU_ALLOC'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16004:17: error: incompatible integer to pointer conversion initializing 'cpu_set_t *' with an expression of type 'int' [-Wint-conversion]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16005:5: error: call to undeclared function 'CPU_ZERO_S'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16007:9: error: call to undeclared function 'CPU_SET_S'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16010:14: error: call to undeclared function 'pthread_setaffinity_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16016:5: error: call to undeclared function 'CPU_FREE'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16024:22: error: call to undeclared function 'CPU_ALLOC_SIZE'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16026:24: error: call to undeclared function 'CPU_ALLOC'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16026:17: error: incompatible integer to pointer conversion initializing 'cpu_set_t *' with an expression of type 'int' [-Wint-conversion]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16027:5: error: call to undeclared function 'CPU_ZERO_S'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16029:9: error: call to undeclared function 'CPU_SET_S'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16032:14: error: call to undeclared function 'pthread_setaffinity_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
~/Projects/github/llama.cpp.zig/llama.cpp/ggml.c:16038:5: error: call to undeclared function 'CPU_FREE'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

I've checked `build.zig` for llama.cpp and I've noticed this macro is missing. With this errors are gone.
```
if (ctx.options.target.getAbi() != .msvc)
  lib.defineCMacro("_GNU_SOURCE", null);
```

Maybe would be good also add c and cpp flags like there?

Out of context: I was just trying to bind llama.cpp to zig and found this lib. Awesome to see it. Great work. :clap: 