### PR TITLE
cpp grammar bindings

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,8 @@ pub const Context = struct {
     llama_h_module: *Module,
     /// ggml.h  translated header file module, mostly for internal use
     ggml_h_module: *Module,
+    /// cpp_bindings.h translated header file module, mostly for internal use
+    llama_cpp_bindings_h_module: *Module,
 
     pub fn init(b: *std.Build, options: Options) Self {
         var zop = b.addOptions();
@@ -47,6 +49,7 @@ pub const Context = struct {
 
         const llama_h_module = llama_cpp.moduleLlama();
         const ggml_h_module = llama_cpp.moduleGgml();
+        const llama_cpp_bindings_h_module = llama_cpp.moduleLlamaCppBindings();
         const deps: []const std.Build.ModuleDependency = &.{
             .{
                 .name = "llama.h",
@@ -55,6 +58,10 @@ pub const Context = struct {
             .{
                 .name = "ggml.h",
                 .module = ggml_h_module,
+            },
+            .{
+                .name = "llama_cpp_bindings.h",
+                .module = llama_cpp_bindings_h_module,
             },
             .{
                 .name = "llama_options",
@@ -73,6 +80,7 @@ pub const Context = struct {
             .module = mod,
             .llama_h_module = llama_h_module,
             .ggml_h_module = ggml_h_module,
+            .llama_cpp_bindings_h_module = llama_cpp_bindings_h_module
         };
     }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,7 +12,7 @@
     .dependencies = .{
         .clblast = .{
             .url = "https://github.com/Deins/CLBlast.build.zig/archive/refs/tags/0.0.2.tar.gz",
-            .hash = "12206fa67c773ff701dd7c2a41d910b55be4637b2502c46c0522655ebd22a74b1b14",
+            .hash = "1220a1af933f264866c25daa10faebd413f23192e420bc35ca988d36ec53a5f692ac",
         },
     },
 }

--- a/cpp_bindings/bindings.h
+++ b/cpp_bindings/bindings.h
@@ -1,0 +1,1 @@
+#include "grammar.h"

--- a/cpp_bindings/grammar.cpp
+++ b/cpp_bindings/grammar.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <grammar-parser.h>
+
+extern "C" llama_grammar * parse_grammar_from_text(const char * str) {
+    grammar_parser::parse_state parsed_state = grammar_parser::parse(str);
+    std::vector<const llama_grammar_element *> grammar_rules(parsed_state.c_rules());
+
+    return llama_grammar_init(grammar_rules.data(), grammar_rules.size(), parsed_state.symbol_ids.at("root"));
+}

--- a/cpp_bindings/grammar.h
+++ b/cpp_bindings/grammar.h
@@ -1,0 +1,3 @@
+#include "llama.h"
+
+struct llama_grammar * parse_grammar_from_text(const char *);

--- a/llama.cpp.zig/prompt.zig
+++ b/llama.cpp.zig/prompt.zig
@@ -265,6 +265,7 @@ pub fn generateAppendOne(self: *@This()) !Token {
     const new_token = try self.sampling.sample(self.ctx, null, self.batch.n_tokens - 1);
     self.tokens_mutex.unlock();
     try self.addOneToken(new_token);
+    if (self.sampling.grammar != null) self.sampling.accept(self.ctx, new_token, true);
     return new_token;
 }
 


### PR DESCRIPTION
Issue: #2
Adds cpp bindings for grammar and prompt handling

TODO:
- [ ] add error handling for wrong grammar

examples:
`zig-out/bin/simple --model_path /home/user/model.gguf --prompt "What are the 10 biggest countries in the world?" --grammar_file_path llama.cpp/grammars/list.gbnf`

`zig-out/bin/simple --model_path /home/user/model.gguf --prompt "Prepare me a json schema for country informations." --grammar_file_path llama.cpp/grammars/json.gbnf`